### PR TITLE
fix: cannot get app after succeed to refresh token

### DIFF
--- a/app/middleware/auth.go
+++ b/app/middleware/auth.go
@@ -65,7 +65,7 @@ func Auth(cfg *config.Config) zoox.HandlerFunc {
 				// @2 check user
 				if user, _, err := service.GetUser(ctx, cfg, token); err == nil && user != nil {
 					// @3 check app
-					if app, _, err := service.GetApp(ctx, cfg, provider, token); err != nil && app == nil {
+					if app, _, err := service.GetApp(ctx, cfg, provider, service.GetToken(ctx)); err != nil && app == nil {
 						if from != "" {
 							ctx.Session().Del("from")
 							ctx.Redirect(from)
@@ -156,7 +156,7 @@ func Auth(cfg *config.Config) zoox.HandlerFunc {
 			service.DelToken(ctx)
 			ctx.Redirect(fmt.Sprintf("/login?from=%s&reason=%s", url.QueryEscape(ctx.Request.RequestURI), "user_expired"))
 			return
-		} else if app, _, err := service.GetApp(ctx, cfg, provider, token); err != nil || app == nil {
+		} else if app, _, err := service.GetApp(ctx, cfg, provider, service.GetToken(ctx)); err != nil || app == nil {
 			// [visit real path] @2 check app
 			// @TODO
 			// sleep for a while to avoid too many requests

--- a/app/service/user.go
+++ b/app/service/user.go
@@ -87,7 +87,7 @@ func GetUser(ctx *zoox.Context, cfg *config.Config, token string) (*User, int, e
 							logger.Infof("[service.GetUser][RefreshToken] token refreshed: %#v (failed to marshal token with json)", token)
 						} else {
 							logger.Infof("[service.GetUser][RefreshToken] token refreshed: %s", j)
-						fi
+						}
 
 						SetToken(ctx, cfg, token.AccessToken)
 						// @TODO should not change refresh token because it will not case refresh token expired

--- a/app/service/user.go
+++ b/app/service/user.go
@@ -83,7 +83,11 @@ func GetUser(ctx *zoox.Context, cfg *config.Config, token string) (*User, int, e
 							return nil, statusCode, fmt.Errorf("failed to refresh token, maybe refresh token expired: %s", err)
 						}
 
-						logger.Infof("[service.GetUser][RefreshToken] token refreshed: %#v", token)
+						if j, err := json.Marshal(token); err != nil {
+							logger.Infof("[service.GetUser][RefreshToken] token refreshed: %#v (failed to marshal token with json)", token)
+						} else {
+							logger.Infof("[service.GetUser][RefreshToken] token refreshed: %s", j)
+						fi
 
 						SetToken(ctx, cfg, token.AccessToken)
 						// @TODO should not change refresh token because it will not case refresh token expired


### PR DESCRIPTION
auth connect log

```bash
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:25 INFO [10.0.1.82:39910][=>] GET /
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:25 INFO [service.GetUser][RefreshToken] refresh_token(057f80707e1514bdd9e06a926d74870cafd1c80c) found, try to refresh token (1) ...
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:25 INFO [service.GetUser][RefreshToken] provider(doreamon) found, try to refresh token (2) ...
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:25 INFO [service.GetUser][RefreshToken] client config(doreamon) found, try to refresh token (3) ...
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:25 INFO [service.GetUser][RefreshToken] client(doreamon) found, try to refresh token (4) ...
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:26 INFO [service.GetUser][RefreshToken] token refreshed: &oauth2.Token{AccessToken:"6106e483fef418fdb9e9d6c2546f3717f80dda56", RefreshToken:"fdd3537f88acf470ea329de352d2b0b800dbaf75", ExpiresIn:3599, TokenType:"Bearer", raw:(*fetch.Response)(0xc0004e61e0)}
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:31 INFO [service.GetUser] user: Zero(tobewhatwewant@gmail.com)
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:32 ERROR [middleware][auth] cannot get app: failed to get app: (status: 401, response: {"code":401,"message":"Token invalid"})
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:32 INFO [10.0.1.82][<=] GET / 302 +7899ms
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:33 INFO [10.0.1.82:55732][=>] GET /login
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:33 INFO [10.0.1.82][<=] GET /login 302 +0ms
memos_memos.1.aodfyaoavvi9@over    | 2024/03/19 18:04:34 INFO [10.0.1.82:55736][=>] GET /login/doreamon
```